### PR TITLE
Update MusicDevice.c

### DIFF
--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -677,7 +677,7 @@ static int NativeMidiInit(MusicDevice *dev, const unsigned int outputIndex, unsi
 #elif defined(__APPLE__)
     // create Core MIDI client
     if (ndev->midiClient) WARN("NativeMidiInit(): midiClient != 0");
-    const OSStatus clientResult = MIDIClientCreate(CFSTR(""systemshockClient"), NULL, NULL, &(ndev->midiClient));
+    const OSStatus clientResult = MIDIClientCreate(CFSTR("systemshockClient"), NULL, NULL, &(ndev->midiClient));
     if (clientResult != noErr)
     {
         WARN("NativeMidiInit(): Failed to create Core MIDI client");


### PR DESCRIPTION
* Fixes possible memory management errors.
* Rename some functions to better match [CoreFoundation naming conventions](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-SW1) (this is not needed, just makes me feel better). 
* Replace unneeded calls to `CFStringCreateWithCString` with just the `CFSTR` macro.